### PR TITLE
Implement `Artwork`

### DIFF
--- a/app/Http/Controllers/ArtworkController.php
+++ b/app/Http/Controllers/ArtworkController.php
@@ -15,7 +15,7 @@ class ArtworkController extends Controller
     public function index(): View
     {
         $viewData = [];
-        $viewData['title'] = __('List of artworks');
+        $viewData['title'] = __('artwork.title.index');
         $viewData['artworks'] = Artwork::all();
 
         return view('artwork.index')->with('viewData', $viewData);
@@ -27,7 +27,7 @@ class ArtworkController extends Controller
 
         $artwork = Artwork::findOrFail($id);
 
-        $viewData['title'] = $artwork->getTitle().' - '.__('Artwork information');
+        $viewData['title'] = __('artwork.title.show', ['artworkTitle' => $artwork->getTitle()]);
         $viewData['artwork'] = $artwork;
 
         return view('artwork.show')->with('viewData', $viewData);

--- a/app/Http/Controllers/ArtworkController.php
+++ b/app/Http/Controllers/ArtworkController.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+namespace App\Http\Controllers;
+
+use App\Models\Artwork;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ArtworkController extends Controller
+{
+    public function index(): View
+    {
+        $viewData = [];
+        $viewData['title'] = __('List of artworks');
+        $viewData['artworks'] = Artwork::all();
+
+        return view('artwork.index')->with('viewData', $viewData);
+    }
+
+    public function show(string $id): View|RedirectResponse
+    {
+        $viewData = [];
+
+        $artwork = Artwork::findOrFail($id);
+
+        $viewData['title'] = $artwork->getTitle().' - '.__('Artwork information');
+        $viewData['artwork'] = $artwork;
+
+        return view('artwork.show')->with('viewData', $viewData);
+    }
+}

--- a/app/Http/Controllers/ArtworkController.php
+++ b/app/Http/Controllers/ArtworkController.php
@@ -7,7 +7,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\Artwork;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
 class ArtworkController extends Controller
@@ -21,7 +20,7 @@ class ArtworkController extends Controller
         return view('artwork.index')->with('viewData', $viewData);
     }
 
-    public function show(string $id): View|RedirectResponse
+    public function show(string $id): View
     {
         $viewData = [];
 

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+
+class Artwork extends Model
+{
+    use HasFactory;
+
+    /**
+     * ARTWORK ATTRIBUTES
+     * $this->attributes['id'] - int - contains the artwork primary key (id)
+     * $this->attributes['title'] - string - contains the artwork name
+     * $this->attributes['author'] - string - contains the author name
+     * $this->attributes['keyword'] - string - contains the keyword
+     * $this->attributes['category'] - string - contains the category
+     * $this->attributes['details'] - string - contains the artwork details
+     * $this->attributes['image'] - string - contains the artwork image
+     * $this->attributes['created_at'] - timestamp - contains the artwork creation date
+     * $this->attributes['updated_at'] - timestamp - contains the artwork update date
+     */
+    public static function validate(Request $request): void
+    {
+        $request->validate([
+            'title' => 'required|max:255',
+            'author' => 'required|max:255',
+            'keyword' => 'required|max:50',
+            'category' => 'required|max:30',
+            'details' => 'required|max:255',
+            'image' => 'required|image',
+        ]);
+    }
+
+    public function getId(): int
+    {
+        return $this->attributes['id'];
+    }
+
+    public function getTitle(): string
+    {
+        return $this->attributes['title'];
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->attributes['title'] = $title;
+    }
+
+    public function getAuthor(): string
+    {
+        return $this->attributes['author'];
+    }
+
+    public function setAuthor(string $author): void
+    {
+        $this->attributes['author'] = $author;
+    }
+
+    public function getKeyword(): string
+    {
+        return $this->attributes['keyword'];
+    }
+
+    public function setKeyword(string $keyword): void
+    {
+        $this->attributes['keyword'] = $keyword;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->attributes['category'];
+    }
+
+    public function setCategory(string $category): void
+    {
+        $this->attributes['category'] = $category;
+    }
+
+    public function getDetails(): string
+    {
+        return $this->attributes['details'];
+    }
+
+    public function setDetails(string $details): void
+    {
+        $this->attributes['details'] = $details;
+    }
+
+    public function getImage(): string
+    {
+        return $this->attributes['image'];
+    }
+
+    public function setImage($image): void
+    {
+        $this->attributes['image'] = $image;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->attributes['created_at'];
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->attributes['updated_at'];
+    }
+}

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -98,7 +98,7 @@ class Artwork extends Model
         return $this->attributes['image'];
     }
 
-    public function setImage($image): void
+    public function setImage(string $image): void
     {
         $this->attributes['image'] = $image;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
-            "@php artisan migrate --graceful --ansi"
+            "@php artisan migrate --graceful --ansi",
+            "@php artisan storage:link"
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",

--- a/database/factories/ArtworkFactory.php
+++ b/database/factories/ArtworkFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ArtworkFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->randomElement([
+                'Salvator Mundi', 'Interchange', 'The Card Players',
+                'Nafea Faa Ipoipo (When Will You Marry?)', 'Number 17A',
+                'Wasserschlangen II', 'No. 6 (Violet, Green and Red)',
+                'Pendant portraits of Maerten Soolmans and Oopjen Coppit',
+                'Les Femmes d\'Alger ("Version O")', 'The Standard Bearer',
+                'Shot Sage Blue Marilyn', 'Nu couché', 'No. 5, 1948',
+                'Woman III', 'Masterpiece', 'Portrait of Adele Bloch-Bauer I',
+                'Le Rêve', 'Portrait of Dr. Gachet',
+                'Portrait of Adele Bloch-Bauer II',
+            ]),
+            'author' => $this->faker->randomElement([
+                'Peter Agostini', 'Lucien den Arend', 'Karl Bitter',
+                'Percival Ball', 'Michael Boroniec', 'Hans Van de Bokenvamp',
+                'Jacob Burck', 'Estella Campavias', 'Nancy Carline',
+                'Bartolomeo Cavaceppi', 'Thomas Hart Benton', 'Fernando Botero',
+                'Clarence Holbrook Carter', 'Charles Conder', 'Sonia Delaunay',
+                'Elizabeth Durack', 'M. C. Escher', 'Joaquín Torres García',
+                'Natalia Goncharova', 'Nina Genke-Meller', 'Elaine Hamilton',
+                'Friedensreich Hundertwasser', 'František Kupka', 'László Moholy-Nagy',
+            ]),
+            'keyword' => $this->faker->word(),
+            'category' => $this->faker->randomElement([
+                'Painting', 'Sculpture', 'Photography', 'Digital', 'Drawing',
+            ]),
+            'details' => $this->faker->text(maxNbChars: 200),
+            'image' => 'default.png',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/0002_01_01_000001_create_artworks_table.php
+++ b/database/migrations/0002_01_01_000001_create_artworks_table.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('artworks', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('author');
+            $table->string('keyword');
+            $table->string('category')->default('Uncategorized');
+            $table->string('details');
+            $table->string('image')->default('default.png');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('artworks');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Models\Artwork;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +13,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        Artwork::factory(5)->create();
     }
 }

--- a/lang/en/artwork.php
+++ b/lang/en/artwork.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+return [
+    'title' => [
+        'index' => 'List of artworks',
+        'show' => ':artworkTitle - Artwork information',
+    ],
+    'index' => [
+        'no_artworks' => 'No artworks available in the gallery yet.',
+    ],
+    'show' => [
+        'about' => 'About this piece',
+        'artworkID' => 'Artwork ID: :artworkID',
+        'by' => 'By :author',
+    ],
+];

--- a/lang/es/artwork.php
+++ b/lang/es/artwork.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @author Luis Torres
+ */
+
+return [
+    'title' => [
+        'index' => 'Lista de obras de arte',
+        'show' => ':artworkTitle - Información sobre la obra de arte',
+    ],
+    'index' => [
+        'no_artworks' => 'No hay obras de arte disponibles en la galería en este momento.',
+    ],
+    'show' => [
+        'about' => 'Sobre esta obra',
+        'artworkID' => 'Identificador de la obra: :artworkID',
+        'by' => 'Por :author',
+    ],
+];

--- a/resources/views/artwork/index.blade.php
+++ b/resources/views/artwork/index.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+@section('title', $viewData['title'])
+@section('content')
+    {{-- Generated with Claude Sonnet 3.5. --}}
+    <div class="container my-4">
+        @if ($viewData['artworks']->isEmpty())
+            <div class="alert alert-info" role="alert">
+                <p class="mb-0">No artworks available in the gallery yet.</p>
+            </div>
+        @endif
+
+        <div class="row row-cols-1 row-cols-md-3 g-4">
+            @foreach ($viewData['artworks'] as $artwork)
+                <a href="{{ route('artwork.show', ['id' => $artwork->getId()]) }}" class="text-decoration-none text-dark">
+                    <div class="col">
+                        <div class="card h-100 shadow-sm">
+                            <img src="{{ asset('/storage/' . $artwork->getImage()) }}" class="card-img-top"
+                                alt="{{ $artwork->getTitle() }}">
+                            <div class="card-body">
+                                <h5 class="card-title text-dark fw-semibold">
+                                    {{ $artwork->getTitle() }}
+                                </h5>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/resources/views/artwork/index.blade.php
+++ b/resources/views/artwork/index.blade.php
@@ -5,7 +5,7 @@
     <div class="container my-4">
         @if ($viewData['artworks']->isEmpty())
             <div class="alert alert-info" role="alert">
-                <p class="mb-0">No artworks available in the gallery yet.</p>
+                <p class="mb-0">{{ __('artwork.index.no_artworks') }}</p>
             </div>
         @endif
 

--- a/resources/views/artwork/index.blade.php
+++ b/resources/views/artwork/index.blade.php
@@ -11,8 +11,8 @@
 
         <div class="row row-cols-1 row-cols-md-3 g-4">
             @foreach ($viewData['artworks'] as $artwork)
-                <a href="{{ route('artwork.show', ['id' => $artwork->getId()]) }}" class="text-decoration-none text-dark">
-                    <div class="col">
+                <div class="col">
+                    <a href="{{ route('artwork.show', ['id' => $artwork->getId()]) }}" class="text-decoration-none text-dark">
                         <div class="card h-100 shadow-sm">
                             <img src="{{ asset('/storage/' . $artwork->getImage()) }}" class="card-img-top"
                                 alt="{{ $artwork->getTitle() }}">
@@ -22,8 +22,8 @@
                                 </h5>
                             </div>
                         </div>
-                    </div>
-                </a>
+                    </a>
+                </div>
             @endforeach
         </div>
     </div>

--- a/resources/views/artwork/show.blade.php
+++ b/resources/views/artwork/show.blade.php
@@ -15,7 +15,7 @@
             <!-- Right side - Details -->
             <div class="col-md-6">
                 <h1 class="display-4 mb-3">{{ $viewData['artwork']->getTitle() }}</h1>
-                <h4 class="text-muted mb-4">By {{ $viewData['artwork']->getAuthor() }}</h4>
+                <h4 class="text-muted mb-4">{{ __('artwork.show.by', ['author' => $viewData['artwork']->getAuthor()]) }}</h4>
 
                 <div class="artwork-details">
                     <div class="category-badge mb-4">
@@ -24,12 +24,12 @@
                     </div>
 
                     <div class="description mb-4">
-                        <h5 class="text-primary">About this piece</h5>
+                        <h5 class="text-primary">{{ __('artwork.show.about') }}</h5>
                         <p class="lead">{{ $viewData['artwork']->getDetails() }}</p>
                     </div>
 
                     <div class="artwork-meta text-muted">
-                        <small>Artwork ID: {{ $viewData['artwork']->getId() }}</small>
+                        <small>{{ __('artwork.show.artworkID', ['artworkID' => $viewData['artwork']->getId()]) }}</small>
                     </div>
                 </div>
             </div>

--- a/resources/views/artwork/show.blade.php
+++ b/resources/views/artwork/show.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+@section('title', $viewData['title'])
+@section('content')
+    {{-- Generated with Claude Sonnet 3.5. --}}
+    <div class="container mt-5">
+        <div class="row">
+            <!-- Left side - Image -->
+            <div class="col-md-6">
+                <div class="artwork-image-container">
+                    <img src="{{ asset('/storage/' . $viewData['artwork']->getImage()) }}" class="img-fluid rounded shadow"
+                        alt="{{ $viewData['artwork']->getTitle() }}">
+                </div>
+            </div>
+
+            <!-- Right side - Details -->
+            <div class="col-md-6">
+                <h1 class="display-4 mb-3">{{ $viewData['artwork']->getTitle() }}</h1>
+                <h4 class="text-muted mb-4">By {{ $viewData['artwork']->getAuthor() }}</h4>
+
+                <div class="artwork-details">
+                    <div class="category-badge mb-4">
+                        <span class="badge bg-secondary">{{ $viewData['artwork']->getCategory() }}</span>
+                        <span class="badge bg-info">{{ $viewData['artwork']->getKeyword() }}</span>
+                    </div>
+
+                    <div class="description mb-4">
+                        <h5 class="text-primary">About this piece</h5>
+                        <p class="lead">{{ $viewData['artwork']->getDetails() }}</p>
+                    </div>
+
+                    <div class="artwork-meta text-muted">
+                        <small>Artwork ID: {{ $viewData['artwork']->getId() }}</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -9,7 +9,8 @@
                 <li><a href="{{ route('home.index') }}" class="nav-link px-2 text-secondary">{{ __('Home') }}</a>
                 </li>
                 <li><a href="{{ route('home.index') }}" class="nav-link px-2 text-white">{{ __('Auction') }}</a></li>
-                <li><a href="{{ route('home.index') }}" class="nav-link px-2 text-white">{{ __('Artwork') }}</a></li>
+                <li><a href="{{ route('artwork.index') }}" class="nav-link px-2 text-white">{{ __('Artworks') }}</a>
+                </li>
                 <li><a href="{{ route('home.index') }}" class="nav-link px-2 text-white">{{ __('About') }}</a></li>
             </ul>
             <div class="d-flex text-end">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
+use App\Http\Controllers\ArtworkController;
+use App\Http\Controllers\HomeController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', 'App\Http\Controllers\HomeController@index')->name('home.index');
+Route::controller(HomeController::class)->group(function () {
+    Route::get('/', 'index')->name('home.index');
+});
+
+Route::controller(ArtworkController::class)->group(function () {
+    Route::get('/artwork/list', 'index')->name('artwork.index');
+    Route::get('/artwork/{id}', 'show')->name('artwork.show');
+});
 
 Auth::routes();


### PR DESCRIPTION
# Changes

1. `Artwork` model as per the current [class diagram](https://github.com/luismtorresv/ArsLonga/wiki/Deliverable-1#class-diagram).
2. Views of list of artworks and product page.
3. Define a factory with some artwork titles and artists (they are pulled at random, not actually matching artwork-author).

# Extra details

1. `post-create-project-cmd` composer script creates symbolic link to `storage`.
2. Localized views.