### PR TITLE
Set up the lefthook Git hooks manager

### DIFF
--- a/.config/lefthook.yaml
+++ b/.config/lefthook.yaml
@@ -1,0 +1,19 @@
+assert_lefthook_installed: true
+min_version: 2.0.0
+
+pre-commit:
+  # parallel: true
+  follow: true
+  jobs:
+    - name: static analysis
+      tags:
+        - backend
+        - static-analysis
+      run: ./vendor/bin/phpstan
+    - name: lint backend
+      tags:
+        - backend
+        - linters
+      run: ./vendor/bin/pint {staged_files}
+      stage_fixed: true
+      interactive: false


### PR DESCRIPTION
lefthook is a Git hooks manager, that is, a tool that lets you define custom commands to be run, say, before committing or after merging. This allows us to reduce noise caused by forgetting to run pint or phpstan without too much setup effort.

You may install lefthook on Windows following [these instructions](https://lefthook.dev/installation/winget.html). After you've installed lefthook, you can go to the project root and run `lefthook install`, so the hooks are created (this creates the corresponding `.git/hooks/*` files for you). After doing this, lefthook should be all set up.

If you're curious about the configuration file, you can check it out at `.config/lefthook.yaml`.