### PR TITLE
Move image saving logic to a utilities directory

### DIFF
--- a/app/Http/Controllers/Admin/AdminArtworkController.php
+++ b/app/Http/Controllers/Admin/AdminArtworkController.php
@@ -93,6 +93,7 @@ class AdminArtworkController extends Controller
         $artwork = Artwork::findOrFail($id);
 
         $artwork->deleteImageFromDisk();
+        $artwork->delete();
 
         return redirect()->route('admin.artwork.index');
     }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -65,7 +65,6 @@ class Artwork extends Model
         if ($this->getImage() !== 'default.png') {
             Storage::disk('public')->delete($this->getImage());
         }
-        $this->delete();
 
     }
 


### PR DESCRIPTION
Move both the save and delete functions to the artwork model, so that the Storage import only gets used once. I also found a bug, which i'm going to make into another issue